### PR TITLE
Fix Java-Time Instant serialization precision

### DIFF
--- a/macros/src/main/scala/com/evolutiongaming/kryo/Serializer.scala
+++ b/macros/src/main/scala/com/evolutiongaming/kryo/Serializer.scala
@@ -124,7 +124,7 @@ object Serializer {
           } else if (tpe =:= typeOf[DateTime]) {
             q"output.writeLong($arg.getMillis)"
           } else if (tpe =:= typeOf[Instant]) {
-            q"output.writeLong($arg.toEpochMilli)"
+            q"output.writeLong($arg.getEpochSecond); output.writeInt($arg.getNano)"
           } else if (tpe =:= typeOf[FiniteDuration]) {
             q"output.writeLong($arg.toMillis)"
           } else if (tpe <:< typeOf[Option[_]]) withWriterFor(tpe, arg) {
@@ -206,7 +206,7 @@ object Serializer {
           } else if (tpe =:= typeOf[DateTime]) {
             q"new org.joda.time.DateTime(input.readLong)"
           } else if (tpe =:= typeOf[Instant]) {
-            q"java.time.Instant.ofEpochMilli(input.readLong)"
+            q"java.time.Instant.ofEpochSecond(input.readLong, input.readInt)"
           } else if (tpe =:= typeOf[FiniteDuration]) {
             q"new scala.concurrent.duration.FiniteDuration(input.readLong, java.util.concurrent.TimeUnit.MILLISECONDS).toCoarsest.asInstanceOf[scala.concurrent.duration.FiniteDuration]"
           } else if (tpe <:< typeOf[Option[_]]) withReaderFor(tpe) {

--- a/macros/src/test/scala/com/evolutiongaming/kryo/SerializerMacroSpec.scala
+++ b/macros/src/test/scala/com/evolutiongaming/kryo/SerializerMacroSpec.scala
@@ -79,8 +79,11 @@ class SerializerMacroSpec extends WordSpec with Matchers {
     "serialize and deserialize standard types" in {
       case class Types(str: String, bd: BigDecimal, id: UUID, dt: DateTime, inst: Instant, dur: FiniteDuration)
 
-      verify(Serializer.make[Types], Types("test", 3, new UUID(1L, 2L), DateTime.now(), Instant.now(),
-        FiniteDuration(1234, TimeUnit.MILLISECONDS)))
+      verify(Serializer.make[Types], Types(
+        "test", 3, new UUID(1L, 2L), DateTime.now(),
+        Instant.parse("2018-09-23T14:59:59.100026316Z"),
+        FiniteDuration(1234, TimeUnit.MILLISECONDS)
+      ))
     }
 
     /**


### PR DESCRIPTION
Current implementation uses millisecond-precision. But since Java 9 JVM tries to use microsecond precision on system where it possible - on Linux x64 Oracle JDK it's already there. It means that the current implementation would never satisfy serialisation tests which serialise, deserialise and then compare data which contains Java-Time Instant's. Moreover, on Linux x64 + Oracle JDK current implementation fails it's own tests because of that.
This patch fixes Java-Time Instant serialisation logic so it's represented as Long epoch seconds + Int nanos adjustment, because that's basically what a Java-Time Instant is.
The change is not backward compatible so I believe with it the major library version should be increased to 2. Also a warning should be left in the Readme about possible upgrade issues for the clients.